### PR TITLE
Recent Go version (1.14+) to build TF dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ more][provider-vc] on provider version control.
 ## Prerequisites
 
 If you wish to work on the provider, you'll first need [Go][go-website]
-installed on your machine (version 1.9+ is **required**). You'll also need to
-correctly setup a [GOPATH][gopath], as well as adding `$GOPATH/bin` to your
-`$PATH`.
+installed on your machine (version 1.14+ is **required** to build with 
+current dependencies). You'll also need to correctly setup a [GOPATH][gopath], 
+as well as adding `$GOPATH/bin` to your `$PATH`.
 
 [go-website]: https://golang.org/
 [gopath]: http://golang.org/doc/code.html#GOPATH


### PR DESCRIPTION
Ubuntu 18.04 with distro-provided go (v1.10) doesn't work as it fails to build TF:
```
make build
==> Checking that code complies with gofmt requirements...
go install
# github.com/hashicorp/terraform/lang/funcs
../../hashicorp/terraform/lang/funcs/crypto.go:164:14: undefined: strings.ReplaceAll
../../hashicorp/terraform/lang/funcs/crypto.go:166:14: undefined: strings.ReplaceAll
GNUmakefile:9: recipe for target 'build' failed
make: *** [build] Error 2
```
Maybe some intermediate versions (v1.13, etc.) could work but it's easiest to use the current to build.
We already provide an example with v1.14.1 so it's probably easiest to stick with v1.14 or newer.