### PR TITLE
Fix typos, make improvements, improve examples, add validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+examples/elementsw/terraform.tfstate*
+examples/elementsw/terraform.tfvars
+examples/elementsw/.terraform/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
+<!-- TOC -->
+
+- [Terraform NetApp ElementSW Provider](#terraform-netapp-elementsw-provider)
+    - [Naming Conventions](#naming-conventions)
+    - [Using the Provider](#using-the-provider)
+        - [Provider Documentation](#provider-documentation)
+        - [Controlling the provider version](#controlling-the-provider-version)
+    - [Building The Provider](#building-the-provider)
+        - [Prerequisites](#prerequisites)
+        - [Cloning the Project](#cloning-the-project)
+        - [Running the Build](#running-the-build)
+        - [Installing the Local Plugin](#installing-the-local-plugin)
+    - [Developing the Provider](#developing-the-provider)
+    - [Testing the Provider](#testing-the-provider)
+        - [Configuring Environment Variables](#configuring-environment-variables)
+            - [Using the .tf-elementsw-devrc.mk file](#using-the-tf-elementsw-devrcmk-file)
+        - [Running the Acceptance Tests](#running-the-acceptance-tests)
+        - [Walkthrough example](#walkthrough-example)
+            - [Installing Go and Terraform](#installing-go-and-terraform)
+            - [Installing dependencies](#installing-dependencies)
+            - [Cloning the NetApp provider repository and building the provider](#cloning-the-netapp-provider-repository-and-building-the-provider)
+            - [Sanity check](#sanity-check)
+
+<!-- /TOC -->
+
 # Terraform NetApp ElementSW Provider
 
 This is the repository for the Terraform NetApp ElementSW Provider, which can be used with Terraform to configure resources on NetApp HCI or SolidFire storage clusters.
@@ -9,50 +34,53 @@ For general information about Terraform, visit the [official website][tf-website
 
 This provider plugin was initially developed by the SolidFire team for use with internal projects. The provider plugin was refactored to be published and maintained.
 
-This provider was tested with ElementSW versions ranging from 11.1 up to 12.2.
+This provider was tested with ElementSW versions ranging from 11.1 up to 12.
 
 ## Naming Conventions
 
-ElementSW does not require resource names to be unique.  They are considered as 'labels' and resources in ElementSW are uniquely identified by 'ids'.  However these ids are not
-user friendly, and as they are generated on the fly, they make it difficult to track resources and automate.
+ElementSW does not require resource names to be unique.  They are considered as 'labels' and resources in ElementSW are uniquely identified by 'ids'.  However these ids are not user friendly, and as they are generated on the fly, they make it difficult to track resources and automate.
 
-This provider assumes that resource names are unique, and enforces it within its scope. This is not an issue if everything is managed through Terraform, but could raise
-conflicts if the rule is not respected outside of Terraform.
+This provider assumes that resource names are unique, and enforces it within its scope. This is not an issue if everything is managed through Terraform, but could raise conflicts if the rule is not respected outside of Terraform.
 
 ## Using the Provider
 
 The current version of this provider requires Terraform 0.12 or higher to run.
 
-You will need to build the provider before being able to use it (see [the section below](#building-the-provider))
+- Newer Terraform releases such as 1.0.6 can download the provider from [Terraform Registry](https://registry.terraform.io/) so there's no need to build it from source. A complete how-to based on Terraform 1.0.6 and SolidFire 12.3 can be found [here](https://github.com/NetApp/terraform-provider-netapp-elementsw/tree/master/examples/elementsw).
+- Users of older Terraform releases such as Terraform 0.12 may need to build the provider from source before being able to use it, and load it locally (see [the section below](#building-the-provider)).
 
 Note that you need to run `terraform init` to fetch the provider before deploying.
 
 ### Provider Documentation
 
-<TBD> The provider is documented [here][tf-elementsw-docs].
+The provider is documented [here](https://registry.terraform.io/providers/NetApp/netapp-elementsw/latest/docs).
 
 Check the provider documentation for details on entering your connection information and how to get started with writing configuration for NetApp ElementSW resources.
 
-[tf-elementsw-docs](website/docs/index.html.markdown)
-
 ### Controlling the provider version
 
-Note that you can also control the provider version. This requires the use of a `provider` block in your Terraform configuration if you have not added one already.
+Note that you can also control the provider version. Since Terraform 0.13 this requires the use of a `required_providers` block in your Terraform configuration.
 
-The syntax is as follows:
+The syntax that loads the provider from Terraform Registry is as follows:
 
 ```hcl
-provider "netapp-elementsw" {
-  version = "~> 1.1"
-  ...
+required_providers {
+  netapp-elementsw = {
+    version = "~> 20.11"
+    source  = "NetApp/netapp-elementsw"
+  }
 }
 ```
 
-Version locking uses a pessimistic operator, so this version lock would mean anything within the 1.x namespace, including or after 1.1.0. Read more [here][provider-vc] on provider version control.
+Version locking uses a pessimistic operator, so this version lock would mean anything within the 20.11 namespace, including or after 20.11.0. Read more [here][provider-vc] on provider version control.
 
-[provider-vc]: https://www.terraform.io/docs/configuration/providers.html#provider-versions
+For offline loading please see the walk-through for building from source.
+
+[provider-vc]: https://www.terraform.io/docs/language/providers/requirements.html#version
 
 ## Building The Provider
+
+This section is intended for developers. Regular users can start with this ready-to-use [example](https://github.com/NetApp/terraform-provider-netapp-elementsw/tree/master/examples/elementsw).
 
 ### Prerequisites
 
@@ -108,7 +136,7 @@ See [Building the Provider](#building-the-provider) for details on building the 
 
 ## Testing the Provider
 
-**NOTE:** Testing the NetApp ElementSW provider is currently a complex operation as it requires having an ElementSW endpoint to test against, which should be hosting a standard configuration for a HCI or SolidFire cluster.
+**NOTE:** Testing the NetApp ElementSW provider is currently a complex operation as it requires having an ElementSW endpoint to test against, which should be hosting a standard configuration for a HCI or SolidFire cluster. If you have a NetApp Support account, you may instead download Element Demo VM 12 from the Tools section, and deploy a singleton VM-based SolidFire cluster on VMware.
 
 ### Configuring Environment Variables
 
@@ -134,9 +162,11 @@ make testacc TESTARGS="-run=TestAccElementSwVolume"
 
 This following example would run all of the acceptance tests matching `TestAccElementSwVolume`. Change this for the specific tests you want to run.
 
-## Walkthrough example
+### Walkthrough example
 
-### Installing Go and Terraform
+If you are not building from source or want to download provider from online Terraform Registry, please refer to README in the subdirectory examples/elementsw.
+
+#### Installing Go and Terraform
 
 ```sh
 bash
@@ -160,7 +190,7 @@ unzip terraform_0.12.24_linux_amd64.zip
 mv terraform $GO_INSTALL_DIR/go/bin
 ```
 
-### Installing dependencies
+#### Installing dependencies
 
 ```sh
 # make sure git is installed
@@ -176,7 +206,7 @@ go get github.com/x-cray/logrus-prefixed-formatter
 Note getting the terraform package also builds and installs terraform in $GOPATH/bin.
 The version in go/bin is a stable release.
 
-### Cloning the NetApp provider repository and building the provider
+#### Cloning the NetApp provider repository and building the provider
 
 ```sh
 mkdir -p $GOPATH/src/github.com/netapp
@@ -187,11 +217,20 @@ make build
 mv $GOPATH/bin/terraform-provider-netapp-elementsw $GO_INSTALL_DIR/go/bin
 ```
 
-The build step will install the provider in the $GOPATH/bin directory. For Terraform v0.11 and v0.12 you could use it from there, for version v0.13 copy it to `/usr/share/terraform/providers/netapp.com/` (see the provided example).
+The build step will install the provider in the $GOPATH/bin directory. For Terraform 0.11 and 0.12 you could use it from there, for version 0.13 and later, copy it to `/usr/share/terraform/providers/netapp.com/` and load it with:
 
-### Sanity check
+```hcl
+required_providers {
+  netapp-elementsw = {
+    version = "0.1.0"
+    source = "netapp.com/elementsw/netapp-elementsw"
+  }
+}
+```
 
-```shell
+#### Sanity check
+
+```sh
 cd examples/elementsw/
 terraform init
 ```

--- a/examples/elementsw/README.md
+++ b/examples/elementsw/README.md
@@ -54,7 +54,7 @@ Because some variables in this example have values set in `resources.tf` and som
 terraform apply \
   -var="elementsw_username=admin" \
   -var="elementsw_password=admin" \
-  -var="elementsw_cluster=192.168.1.34" \
+  -var="elementsw_server=192.168.1.34" \
   -var="volume_name=testVol" \
   -var="volume_size_list=[1073742000,1073742000]"
 ```

--- a/examples/elementsw/README.md
+++ b/examples/elementsw/README.md
@@ -1,47 +1,101 @@
-# NetApp ElementSW 0.1.0 Example
+# NetApp ElementSW v20.11 Example
 
 This repository is designed to demonstrate the capabilities of the [Terraform
-NetApp ElementSW Provider][ref-tf-elementsw] at the time of the 0.1.0 release.
+NetApp ElementSW Provider][ref-tf-elementsw].
 
-[ref-tf-elementsw]: https://www.terraform.io/docs/providers/netapp/elementsw/index.html
+[ref-tf-elementsw]: https://registry.terraform.io/providers/NetApp/netapp-elementsw/latest
 
-This example performs the following:
+On `terraform apply`, this example performs the following:
 
-* Sets up an account. This uses the
-  [`elementsw_account` resource][ref-tf-elementsw-account].
+* Sets up an account. This uses the `elementsw_account` resource
 * Creates a number of volumes on the cluster tied to the account,
-  using the [`elementsw_volume` resource][ref-tf-elementsw-volume].
+  using the `elementsw_volume` resource.
 * Sets up a volume access group (VAG) for the volumes, using the
-  [`elementsw_volume_access_group` resource][ref-tf-elementsw-volume-access-group].
+  `elementsw_volume_access_group` resource.
 * Finally, creates an initiator tied to the volume access group and volumes using
-  the [`elementsw_initiator` resource][ref-tf-elementsw-initiator].
+  the `elementsw_initiator` resource.
 
-[ref-tf-elementsw-account]: https://www.terraform.io/docs/providers/netapp/elementsw/r/account.html
-[ref-tf-elementsw-initiator]: https://www.terraform.io/docs/providers/netapp/elementsw/r/initiator.html
-[ref-tf-elementsw-volume]: https://www.terraform.io/docs/providers/netapp/elementsw/r/volume.html
-[ref-tf-elementsw-volume-access-group]: https://www.terraform.io/docs/providers/netapp/elementsw/r/volume_access_group.html
+On `terraform destroy`, it removes all the resources (volumes are purged, not just deleted).
 
 ## Requirements
 
-* A working NetApp HCI or SolidFire storage cluster.
+* NetApp HCI, SolidFire or eSDS storage cluster (including Element Demo VM)
+* Terraform client
 
-## Usage Details
+## Getting Started
 
-You can either clone the entire
-[terraform-provider-elementsw][ref-tf-elementsw-github] repository, or download the
-`provider.tf`, `variables.tf`, `resources.tf`, and
-`terraform.tfvars.example` files into a directory of your choice. Once done,
-run `terraform init`, edit the `terraform.tfvars.example` file, populating the fields with the
-relevant values, and then rename it to `terraform.tfvars`. Don't forget to
-configure your endpoint and credentials by either adding them to the
-`terraform.tfvars` file, or by using environment variables. See
-[here][ref-tf-elementsw-provider-settings] for a reference on provider-level
-configuration values.
+Clone the Git repository and change directory to the ElementSW examples directory:
 
-[ref-tf-elementsw-github]: https://github.com/terraform-providers/terraform-provider-netapp-elementsw
-[ref-tf-elementsw-provider-settings]: https://www.terraform.io/docs/providers/netapp/elementsw/index.html#argument-reference
+```sh
+git clone https://github.com/NetApp/terraform-provider-netapp-elementsw
+cd terraform-provider-netapp-elementsw/examples/elementsw
+terraform init
+```
 
-Once done, run `terraform plan` to review the plan, then `terraform apply` to execute.
+`terraform init` should download ElementSW provider to `.terraform` in the current path.
 
-If you use Terraform 0.11.0 or higher, you can skip `terraform plan` as `terraform apply`
-will now perform the plan for you and ask you confirm the changes.
+**NOTE:** Before you continue make sure that volume names, sizes, IQN and other variables from the examples do not conflict with your production environment. Pay special attention when referencing volumes when volumes get deleted earlier than others (so that `testVol-5` becomes one of only three volumes you're working with, and you need to delete the second volume named `testVol-3`). As mentioned in the main README file, you may download Element (SolidFire) Demo VM for safe experimenting.
+
+What's in the files?
+
+- provider.tf - provider settings
+- resources.tf - description of resources the provider can manage
+- variables.tf - description of some variables that may be used with teh provider (also see terraform.tfvars.example)
+- version.tf - provider version control file that downloads ElementSW provider from Terraform Registry. To load own copy, please see the main README file (about building from source)
+- terraform.tfvars.example - sample file with variables
+
+### Without terraform.tfvars
+
+Without a variables file we need to make sure Terraform has all of the required variables.
+
+Because some variables in this example have values set in `resources.tf` and some have defaults defined in `variables.tf`, the number of variables we have to provide via command line can be less than the total number of required variables. For example, `elementsw_username` is already defined in `variables.tf` and `elementsw_initiator` in `resources.tf`, but we can still override the value of former through the CLI.
+
+```sh
+terraform apply \
+  -var="elementsw_username=admin" \
+  -var="elementsw_password=admin" \
+  -var="elementsw_cluster=192.168.1.34" \
+  -var="volume_name=testVol" \
+  -var="volume_size_list=[1073742000,1073742000]"
+```
+
+Note that in this example `volume_size_list` defaults to `[]` (empty list) in  to avoid potential problems when testing. You can change the default value if you want to change this behavior.
+
+To destroy resources just created, run `terraform destroy` (you need to provide the same set of variables).
+
+### With terraform.tfvars
+
+Descend to examples/elementsw subdirectory and use the sample file to create `terraform.tfvars` and then edit the new file to match your environment:
+
+```sh
+cp terraform.tfvars.example terraform.tfvars
+vim terraform.tfvars
+```
+
+Now run `terraform apply` and `terraform destroy` again, but you may choose to omit (unless you want to override their values from command line) certain variables set in `terraform.tfvars`.
+
+Once done, optionally run `terraform plan` to review the plan, then use `terraform apply` to execute. Destroy with `terraform destroy`, the same as earlier.
+
+### Add own validation rules
+
+To implement own naming rules or conventions, feel free to add Terraform validation rules.
+
+In this example we want to ensure that volume names begin with `dc1`.
+
+```hcl
+variable "volume_name" {
+  type        = string
+  description = "The Element volume name."
+
+  validation {
+    condition     = length(var.volume_name) > 2 && substr(var.volume_name, 0, 3) == "dc1"
+    error_message = "The volume name string must begin with \"dc1\" and have 3 or more characters."
+  }
+}
+```
+
+Another useful example is a validation rule for acceptable volume sizes (min 1Gi, max 16TiB). We could make storage QoS settings variables and add similar validation rules for them, too.
+
+### Extend
+
+If you wish to extend the scope of this provider with minor features, Terraform [generic provisioners](https://www.terraform.io/docs/language/resources/provisioners/file.html) or vendor provisioners may be a convenient way to achieve that without developing in Go.

--- a/examples/elementsw/provider.tf
+++ b/examples/elementsw/provider.tf
@@ -1,6 +1,6 @@
 provider "netapp-elementsw" {
-  username         = var.elementsw_username
-  password         = var.elementsw_password
-  elementsw_server = var.elementsw_cluster
-  api_version      = var.elementsw_api_version
+  username          = var.elementsw_username
+  password          = var.elementsw_password
+  elementsw_server  = var.elementsw_server
+  api_version       = var.elementsw_api_version
 }

--- a/examples/elementsw/provider.tf
+++ b/examples/elementsw/provider.tf
@@ -1,6 +1,6 @@
 provider "netapp-elementsw" {
-  username = var.elementsw_username
-  password = var.elementsw_password
+  username         = var.elementsw_username
+  password         = var.elementsw_password
   elementsw_server = var.elementsw_cluster
-  api_version = var.elementsw_api_version
+  api_version      = var.elementsw_api_version
 }

--- a/examples/elementsw/resources.tf
+++ b/examples/elementsw/resources.tf
@@ -1,33 +1,32 @@
 # Specify ElementSW resources
 resource "elementsw_account" test-account {
-    provider = netapp-elementsw
-    username = "testAccount"
+  provider = netapp-elementsw
+  username = "testAccount"
 }
 
 resource "elementsw_volume" test-volume {
-    # Create N instances
-    count = length(var.volume_size_list)
-    provider = netapp-elementsw
-    name = "${var.volume_name}-${count.index}"
-
-    account = elementsw_account.test-account.id
-    total_size = var.volume_size_list[count.index]
-    enable512e = true
-    min_iops = 100
-    max_iops = 500
-    burst_iops = 1000
+  # Create N instances
+  count      = length(var.volume_size_list)
+  provider   = netapp-elementsw
+  name       = "${var.volume_name}-${count.index}"
+  account    = elementsw_account.test-account.id
+  total_size = var.volume_size_list[count.index]
+  enable512e = true
+  min_iops   = 100
+  max_iops   = 500
+  burst_iops = 1000
 }
 
 resource "elementsw_volume_access_group" test-group {
-    provider = netapp-elementsw
-    name = "testGroup"
-    volumes = elementsw_volume.test-volume.*.id
+  provider = netapp-elementsw
+  name     = "testGroup"
+  volumes  = elementsw_volume.test-volume.*.id
 }
 
 resource "elementsw_initiator" test-initiator {
-    provider = netapp-elementsw
-    name = "iqn.1998-01.com.vmware:test-es65-7f17a50c"
-    alias = "testIQN"
-    volume_access_group_id = elementsw_volume_access_group.test-group.id
-    iqns = elementsw_volume.test-volume.*.iqn
+  provider               = netapp-elementsw
+  name                   = "iqn.1998-01.com.vmware:test-terraform-000000"
+  alias                  = "testIQN"
+  volume_access_group_id = elementsw_volume_access_group.test-group.id
+  iqns                   = elementsw_volume.test-volume.*.iqn
 }

--- a/examples/elementsw/terraform.tfvars.example
+++ b/examples/elementsw/terraform.tfvars.example
@@ -1,6 +1,6 @@
 elementsw_username    = "admin"
 elementsw_password    = "admin"
-elementsw_cluster     = "192.168.1.30"
+elementsw_server      = "192.168.1.30"
 elementsw_api_version = "11.7"
 elementsw_initiator   = "iqn.1998-01.com.netapp:test-terraform-000000"
 volume_name           = "testVol"

--- a/examples/elementsw/terraform.tfvars.example
+++ b/examples/elementsw/terraform.tfvars.example
@@ -1,16 +1,11 @@
-elementsw_username = "admin"
-
-elementsw_password = "admin"
-
-elementsw_cluster = "192.168.1.30"
-
-elementsw_api_version = "10.3"
-
-volume_name = "testVol"
-
-volume_size_list = [
-    "107374182400",
-    "107374182400",
-    "107374182400",
-    "107374182400"
+elementsw_username    = "admin"
+elementsw_password    = "admin"
+elementsw_cluster     = "192.168.1.30"
+elementsw_api_version = "11.7"
+elementsw_initiator   = "iqn.1998-01.com.netapp:test-terraform-000000"
+volume_name           = "testVol"
+volume_size_list      = [
+  "10737418240",
+  "10737418240",
+  "10737418240"
 ]

--- a/examples/elementsw/variables.tf
+++ b/examples/elementsw/variables.tf
@@ -10,7 +10,7 @@ variable "elementsw_password" {
   description = "The password of the Element cluster admin."
 }
 
-variable "elementsw_cluster" {
+variable "elementsw_server" {
   type        = string
   description = "Management Virtual IP (MVIP) of the Element cluster (IPv4 or FQDN)."
 }

--- a/examples/elementsw/variables.tf
+++ b/examples/elementsw/variables.tf
@@ -1,28 +1,47 @@
 variable "elementsw_username" {
-  type = string
+  type        = string
+  default     = "admin"
+  description = "The username of the Element cluster admin."
 }
 
 variable "elementsw_password" {
-  type = string
+  type        = string
+  sensitive   = true
+  description = "The password of the Element cluster admin."
 }
 
 variable "elementsw_cluster" {
-  type = string
+  type        = string
+  description = "Management Virtual IP (MVIP) of the Element cluster (IPv4 or FQDN)."
 }
 
 variable "elementsw_api_version" {
-  type = string
-  default = "10.0"
+  type        = string
+  default     = "11.7"
+  description = "The API version of the Element cluster."
+}
+
+variable "elementsw_initiator" {
+  type        = string
+  default     = "iqn.1998-01.com.netapp:test-terraform-000000"
+  description = "The IQN of the iSCSI client."
 }
 
 variable "volume_name" {
-  type = string 
+  type        = string
+  description = "The Element volume name."
 }
 
 variable "volume_size_list" {
-  type = list
-  default = [
-    "1073741824",
-    "1073741824"
-  ]
+  type        = list(number)
+  default     = [ ]
+  description = "The list of one or more volume sizes in bytes."
+
+  validation {
+    condition     = alltrue([
+      for v in var.volume_size_list :(v >= 1073742000 && v <= 17592190000000) ? true : false
+    ])
+    error_message = "Supported volume sizes are 1 - 16,384 GiB (1073742000 - 17592190000000 bytes)."
+  }
 }
+

--- a/examples/elementsw/version.tf
+++ b/examples/elementsw/version.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     netapp-elementsw = {
-      version = "0.1.0"
-      source = "netapp.com/elementsw/netapp-elementsw"
+      version = ">= 20.11.0"
+      source  = "NetApp/netapp-elementsw"
     }
   }
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -26,7 +26,7 @@ and therefore may undergo significant changes as the community improves it.
 provider "netapp-elementsw" {
   username         = var.elementsw_username
   password         = var.elementsw_password
-  elementsw_server = var.elementsw_cluster
+  elementsw_server = var.elementsw_server
   api_version      = var.elementsw_api_version
 }
 
@@ -68,15 +68,15 @@ resource "elementsw_initiator" test-initiator {
 
 The following arguments are used to configure the ElementSW Provider:
 
-* `elementsw_username` - (Required) This is the username for ElementSW API operations.
-* `elementsw_password` - (Required) This is the password for ElementSW API operations.
-* `elementsw_cluster` - (Required) This is the ElementSW cluster MVIP for ElementSW
+* `username` - (Required) This is the username for ElementSW API operations.
+* `password` - (Required) This is the password for ElementSW API operations.
+* `elementsw_server` - (Required) This is the ElementSW cluster MVIP for ElementSW
   API operations.
-* `elementsw_api_version` - (Required) This is the ElementSW API version for ElementSW
+* `api_version` - (Required) This is the ElementSW API version for ElementSW
   API operations.
 
 ## Required Privileges
 
-These settings were tested with NetApp ElementSW (Element OS, SolidFire) 11.7
+These settings were tested with NetApp ElementSW (Element OS, SolidFire) 11.7.
 For additional information on roles and permissions, please refer to official
 ElementSW documentation.


### PR DESCRIPTION

-  Main README.md - fix broken links, improve instructions, remind of the option to download the provider from Terraform Registry rather than build from source (for non-dev users)
-  Online help for the provider in Terraform Registry - i in iqn was missing
-  Examples subdirectory:
    - Change all HCL files to use Terraform-recommended formatting style
    - Mark SF elementsw_password variable sensitive
    - Fix provider.tf and version.tf files to work with TF 1.0 (maybe they were broken for 0.15, I don't know)
    - Add variable validation for volume size in variables.tf
    -  Add example of customizing validation rules (for volume size list) to readme
   -  Add pointer to extending functionality with other providers
