### PR TITLE
Fix typo, make improvements in variables and validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 examples/elementsw/terraform.tfstate*
 examples/elementsw/terraform.tfvars
-examples/elementsw/.terraform/.terraform*
+examples/elementsw/.terraform

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 examples/elementsw/terraform.tfstate*
 examples/elementsw/terraform.tfvars
-examples/elementsw/.terraform/
+examples/elementsw/.terraform/.terraform*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 examples/elementsw/terraform.tfstate*
 examples/elementsw/terraform.tfvars
-examples/elementsw/.terraform
+examples/elementsw/.terraform/

--- a/examples/elementsw/README.md
+++ b/examples/elementsw/README.md
@@ -54,7 +54,7 @@ Because some variables in this example have values set in `resources.tf` and som
 terraform apply \
   -var="elementsw_username=admin" \
   -var="elementsw_password=admin" \
-  -var="elementsw_server=192.168.1.34" \
+  -var="elementsw_cluster=192.168.1.34" \
   -var="volume_name=testVol" \
   -var="volume_size_list=[1073742000,1073742000]"
 ```
@@ -72,9 +72,28 @@ cp terraform.tfvars.example terraform.tfvars
 vim terraform.tfvars
 ```
 
-Now run `terraform apply` and `terraform destroy` again, but you may choose to omit (unless you want to override their values from command line) certain variables set in `terraform.tfvars`.
+Now run `terraform plan` followed by `terraform apply`. You may still choose to override certain default variables or variables set in `terraform.tfvars`.
 
-Once done, optionally run `terraform plan` to review the plan, then use `terraform apply` to execute. Destroy with `terraform destroy`, the same as earlier.
+Destroy with `terraform destroy`, the same as in the first example.
+
+### Overriding map values from the CLI
+
+This example only shows how values for two maps (QoS and IQN) can be provided from the CLI (Bash shell on Linux). Variations of this approach may be required for different OS.
+
+```sh
+terraform apply \
+  -var="elementsw_username=admin" \
+  -var="elementsw_password=admin" \
+  -var="elementsw_cluster=192.168.1.34" \
+  -var="volume_name=testVol" \
+  -var="volume_size_list=[1073742000,1073742000,1073742000]" \
+  -var="sectorsize_512e=false" \
+  -var="qos={min=100,max=200,burst=300}" \
+  -var="volume_name=dc1-testVol-master" \
+  -var="elementsw_initiator={name=\"iqn.1998-01.com.vmware:test-cluster-000001\",alias=\"testNode1\"}" \
+  -var="voume_group_name=testTenant" \
+  -var="elementsw_tenant_name=testCluster01"
+```
 
 ### Add own validation rules
 
@@ -94,7 +113,7 @@ variable "volume_name" {
 }
 ```
 
-Another useful example is a validation rule for acceptable volume sizes (min 1Gi, max 16TiB). We could make storage QoS settings variables and add similar validation rules for them, too.
+Another useful example is a validation rule for acceptable volume sizes (min 1Gi, max 16TiB) - see `variables.tf`.
 
 ### Extend
 

--- a/examples/elementsw/README.md
+++ b/examples/elementsw/README.md
@@ -91,7 +91,7 @@ terraform apply \
   -var="qos={min=100,max=200,burst=300}" \
   -var="volume_name=dc1-testVol-master" \
   -var="elementsw_initiator={name=\"iqn.1998-01.com.vmware:test-cluster-000001\",alias=\"testNode1\"}" \
-  -var="voume_group_name=testTenant" \
+  -var="volume_group_name=testTenant" \
   -var="elementsw_tenant_name=testCluster01"
 ```
 

--- a/examples/elementsw/provider.tf
+++ b/examples/elementsw/provider.tf
@@ -1,6 +1,6 @@
 provider "netapp-elementsw" {
   username          = var.elementsw_username
   password          = var.elementsw_password
-  elementsw_server  = var.elementsw_server
+  elementsw_server  = var.elementsw_cluster
   api_version       = var.elementsw_api_version
 }

--- a/examples/elementsw/resources.tf
+++ b/examples/elementsw/resources.tf
@@ -19,7 +19,7 @@ resource "elementsw_volume" test-volume {
 
 resource "elementsw_volume_access_group" test-group {
   provider = netapp-elementsw
-  name     = var.voume_group_name
+  name     = var.volume_group_name
   volumes  = elementsw_volume.test-volume.*.id
 }
 

--- a/examples/elementsw/resources.tf
+++ b/examples/elementsw/resources.tf
@@ -1,7 +1,7 @@
 # Specify ElementSW resources
 resource "elementsw_account" test-account {
   provider = netapp-elementsw
-  username = "testAccount"
+  username = var.elementsw_tenant_name 
 }
 
 resource "elementsw_volume" test-volume {
@@ -11,22 +11,22 @@ resource "elementsw_volume" test-volume {
   name       = "${var.volume_name}-${count.index}"
   account    = elementsw_account.test-account.id
   total_size = var.volume_size_list[count.index]
-  enable512e = true
-  min_iops   = 100
-  max_iops   = 500
-  burst_iops = 1000
+  enable512e = var.sectorsize_512e
+  min_iops   = var.qos.min
+  max_iops   = var.qos.max
+  burst_iops = var.qos.burst
 }
 
 resource "elementsw_volume_access_group" test-group {
   provider = netapp-elementsw
-  name     = "testGroup"
+  name     = var.voume_group_name
   volumes  = elementsw_volume.test-volume.*.id
 }
 
 resource "elementsw_initiator" test-initiator {
   provider               = netapp-elementsw
-  name                   = "iqn.1998-01.com.vmware:test-terraform-000000"
-  alias                  = "testIQN"
+  name                   = var.elementsw_initiator.name
+  alias                  = var.elementsw_initiator.alias
   volume_access_group_id = elementsw_volume_access_group.test-group.id
   iqns                   = elementsw_volume.test-volume.*.iqn
 }

--- a/examples/elementsw/terraform.tfvars.example
+++ b/examples/elementsw/terraform.tfvars.example
@@ -1,9 +1,20 @@
 elementsw_username    = "admin"
 elementsw_password    = "admin"
-elementsw_server      = "192.168.1.30"
+elementsw_cluster     = "192.168.1.30"
 elementsw_api_version = "11.7"
-elementsw_initiator   = "iqn.1998-01.com.netapp:test-terraform-000000"
+elementsw_initiator   = {
+  name="iqn.1998-01.com.vmware:test-cluster-000001"
+  alias="testNode1"
+}
 volume_name           = "testVol"
+sectorsize_512e       = true
+voume_group_name      = "testCluster01"
+elementsw_tenant_name = "testCluster01"
+qos                   = {
+  min=100
+  max=200
+  burst=300
+}
 volume_size_list      = [
   "10737418240",
   "10737418240",

--- a/examples/elementsw/terraform.tfvars.example
+++ b/examples/elementsw/terraform.tfvars.example
@@ -8,7 +8,7 @@ elementsw_initiator   = {
 }
 volume_name           = "testVol"
 sectorsize_512e       = true
-voume_group_name      = "testCluster01"
+volume_group_name     = "testCluster01"
 elementsw_tenant_name = "testCluster01"
 qos                   = {
   min=100

--- a/examples/elementsw/variables.tf
+++ b/examples/elementsw/variables.tf
@@ -10,7 +10,7 @@ variable "elementsw_password" {
   description = "The password of the Element cluster admin."
 }
 
-variable "elementsw_server" {
+variable "elementsw_cluster" {
   type        = string
   description = "Management Virtual IP (MVIP) of the Element cluster (IPv4 or FQDN)."
 }
@@ -21,14 +21,30 @@ variable "elementsw_api_version" {
   description = "The API version of the Element cluster."
 }
 
-variable "elementsw_initiator" {
+variable "elementsw_tenant_name" {
   type        = string
-  default     = "iqn.1998-01.com.netapp:test-terraform-000000"
+  default     = "test-account"
+  description = "The Element tenant name."
+}
+
+variable "voume_group_name" {
+  type        = string
+  default     = "test-vag"
+  description = "The volume group name (VAG) of the Element cluster."
+}
+
+variable "elementsw_initiator" {
+  type        = map(string)
+  default     = {
+    name  = "iqn.1998-01.com.netapp:test-terraform-000000"
+    alias = "test-iqn-tf0"
+  }
   description = "The IQN of the iSCSI client."
 }
 
 variable "volume_name" {
   type        = string
+  default     = "testVol"
   description = "The Element volume name."
 }
 
@@ -45,3 +61,22 @@ variable "volume_size_list" {
   }
 }
 
+variable "qos" {
+  type = map(number)
+  default = { 
+    "min"   = 100
+    "max"   = 200
+    "burst" = 300
+  }
+  description = "The SolidFire storage performance QoS settings to apply."
+  validation {
+    condition     = var.qos.min >= 50 && var.qos.min <= 15000 && var.qos.min <= var.qos.max && var.qos.max <= 50000 && var.qos.max <= var.qos.burst && var.qos.burst <= 50000
+    error_message = "SolidFire has rules that apply to QoS values; additionally this environment caps Max and Burst IOPS to <= 50,000."
+  }
+}
+
+variable "sectorsize_512e" {
+  type        = bool
+  default     = true
+  description = "Emulate 512 byte volume sector size (required for ESXi 7.0 and earlier) or not (4096 bytes)."
+}

--- a/examples/elementsw/variables.tf
+++ b/examples/elementsw/variables.tf
@@ -10,7 +10,7 @@ variable "elementsw_password" {
   description = "The password of the Element cluster admin."
 }
 
-variable "elementsw_server" {
+variable "elementsw_cluster" {
   type        = string
   description = "Management Virtual IP (MVIP) of the Element cluster (IPv4 or FQDN)."
 }
@@ -21,14 +21,30 @@ variable "elementsw_api_version" {
   description = "The API version of the Element cluster."
 }
 
-variable "elementsw_initiator" {
+variable "elementsw_tenant_name" {
   type        = string
-  default     = "iqn.1998-01.com.netapp:test-terraform-000000"
+  default     = "test-account"
+  description = "The Element tenant name."
+}
+
+variable "voume_group_name" {
+  type        = string
+  default     = "test-vag"
+  description = "The volume group name (VAG) of the Element cluster."
+}
+
+variable "elementsw_initiator" {
+  type        = map(string)
+  default     = {
+    name  = "iqn.1998-01.com.netapp:test-terraform-000000"
+    alias = "test-iqn-tf0"
+  }
   description = "The IQN of the iSCSI client."
 }
 
 variable "volume_name" {
   type        = string
+  default     = "testVol"
   description = "The Element volume name."
 }
 
@@ -45,3 +61,22 @@ variable "volume_size_list" {
   }
 }
 
+variable "qos" {
+  type = map(number)
+  default = { 
+    "min"   = 100
+    "max"   = 200
+    "burst" = 300
+  }
+  description = "The SolidFire storage performance QoS settings to apply."
+  validation {
+    condition     = var.qos.min > 50 && var.qos.min <= 15000 && var.qos.min < var.qos.max && var.qos.max < 50000 && var.qos.max <= var.qos.burst && var.qos.burst <= 50000
+    error_message = "SolidFire has rules that apply to QoS values; additionally this environment caps Max and Burst IOPS to <= 50,000."
+  }
+}
+
+variable "sectorsize_512e" {
+  type        = bool
+  default     = true
+  description = "Should SolidFire emulate 512 byte block sizes (required for ESXi 7.0 and earlier) or not (4096 bytes)."
+}

--- a/examples/elementsw/variables.tf
+++ b/examples/elementsw/variables.tf
@@ -27,7 +27,7 @@ variable "elementsw_tenant_name" {
   description = "The Element tenant name."
 }
 
-variable "voume_group_name" {
+variable "volume_group_name" {
   type        = string
   default     = "test-vag"
   description = "The volume group name (VAG) of the Element cluster."


### PR DESCRIPTION
- Fix typo in variable name (elementsw_server was used instead of elementsw_cluster)
- Turn more values into variables - now everything can be set through variables
  - QoS now a `map` with Min, Max, Burst values
  - IQN now a `map` (`elementsw_initiator`) with name and alias keys
  - 512e sector emulation now a `bool` (var: `sectorsize_512e`)
  - `volume_group_name`
- Add variable validation
  - QoS - basic sanity checks